### PR TITLE
disable STRICT_TRANS_TABLES

### DIFF
--- a/cms/app/sql/install/new_install.sql
+++ b/cms/app/sql/install/new_install.sql
@@ -1,3 +1,4 @@
+SET sql_mode = ''; # Need to disable STRICT_TRANS_TABLES to allow 0000-00-00 00:00:00 default timestamp used several places in this install file
 --
 -- Table structure for table `activities`
 --


### PR DESCRIPTION
disable STRICT_TRANS_TABLES to allow the 0000-00-00 00:00:00 default timestamp used several places in this install file. I have not run into this as being an issue on recent CentOS setups, but it caused db install to throw an error on my personal dev machine with Server version: 5.7.24-0ubuntu0.18.04.1 (Ubuntu).