### PR TITLE
add name to form so unsaved changes warning works

### DIFF
--- a/cms/modules/case-outcomes.php
+++ b/cms/modules/case-outcomes.php
@@ -40,7 +40,7 @@ else
 		$x[$row['outcome_goal_id']] = $row;
 	}
 	
-	$C .= "<form action=\"{$base_url}/ops/update_case.php\" method=\"POST\">";
+	$C .= "<form action=\"{$base_url}/ops/update_case.php\" method=\"POST\" name=\"ws\">";
 	$C .= "<table class=\"table table-striped\">\n";
 	$i = 0;
 	


### PR DESCRIPTION
Add name attribute with value of "ws" to form so that the unsaved changes warning in ocm/cms/js/form_save.js can work.