### PR TITLE
Two "default" cases in switch/case structure

### DIFF
--- a/cms/app/lib/pikaMisc.php
+++ b/cms/app/lib/pikaMisc.php
@@ -1151,7 +1151,6 @@ class pikaMisc
 			break;
 			
 			case 'case_contact':
-			default:
 			$pager_url = 'case_contact.php';
 			$template_file = 'subtemplates/case_contact_list.html';
 			$case_id = pl_grab_get('case_id');


### PR DESCRIPTION
Starting with PHP 7, PHP does not allow a switch/case structure to have multiple defaults. See https://www.php.net/manual/en/migration70.incompatible.php

This htmlContactList function is only called from a handful of places within Pika, and in none of these places is there a possibility for anything to be passed in besides 'intake', "case_contact', or nothing. And if it is called with no parameter, the function definition sets $mode to 'contacts'. So it does not appear to me that the default: case should even normally come into play. But if it somehow does, I think it makes more sense for it to be on the case: 'contacts' since this corresponds to the default value of the parameter in the function definition.