### PR TITLE
Outcomes Module Behavior

### DIFF
--- a/cms/ops/update_case.php
+++ b/cms/ops/update_case.php
@@ -74,6 +74,13 @@ if ($allow_edits)
 		$case_data->deleteOutcomes();
 		$case_data->addOutcome(pl_grab_post('single_outcome', null, 'number'), 1);
 	}
+	
+	// AC - clear outcomes if the problem code changes
+        if (array_key_exists('prior_problem', $_POST) && array_key_exists('problem', $_POST) && $_POST['prior_problem'] != $_POST['problem'])
+        {
+                $reset_sql = "DELETE FROM outcomes WHERE case_id = {$case_id}";
+                DB::query($reset_sql) or trigger_error("SQL: " . $reset_sql . " Error: " . DB::error());
+        }
 
 }
 

--- a/cms/subtemplates/case-info.html
+++ b/cms/subtemplates/case-info.html
@@ -25,6 +25,7 @@
   </td>
   <td>&nbsp;&nbsp;</td>
   <td nowrap class="de">
+    <input id="prior_problem" name="prior_problem" type="hidden" value="%%[problem]%%">
     %%[lsc_problem_menu]%%<br/>
     Special Problem Code:<br/>
     %%[sp_problem,sp_problem]%%<br/>


### PR DESCRIPTION
One of my clients requested this change. Currently, it is possible for outcomes associated with multiple problem codes to be recorded in a case if a user records outcomes, changes the problem code causing another set of goals to appear, and then records more outcomes. The organization in question attempted to train users to not record outcomes until after they were certain of the correct problem code for the case, but some users continued doing it anyway. They expressed the best way to address the issue was to just delete outcomes from a case when the problem code changes.

If this patch results in behavior that is too heavy-handed for the main code base, that's fine -- you can just reject the patch.