### PR TITLE
MySQL 8 Reserved Word "Groups"

### DIFF
--- a/cms/app/extralib/lib/pikaCms.php
+++ b/cms/app/extralib/lib/pikaCms.php
@@ -1484,7 +1484,7 @@ class pikaCms
 	// GROUPS
 	function fetchGroups()
 	{
-		$sql = "SELECT * FROM groups";
+		$sql = "SELECT * FROM `groups`";
 		$result = DB::query($sql);
 		
 		return $result;
@@ -1493,7 +1493,7 @@ class pikaCms
 	function getGroupsMenuArray()
 	{
 		$a = array();
-		$sql = "SELECT group_id FROM groups";
+		$sql = "SELECT group_id FROM `groups`";
 		$result = DB::query($sql);
 		
 		while ($row = DBResult::fetchRow($result))
@@ -1506,14 +1506,14 @@ class pikaCms
 	
 	function addGroup($a)
 	{
-		$sql = pl_build_sql('INSERT', 'groups', $a);
+		$sql = pl_build_sql('INSERT', '`groups`', $a);
 		$result = DB::query($sql);
 		return $result;
 	}
 	
 	function updateGroup($a)
 	{
-		$sql = pl_build_sql('UPDATE', 'groups', $a);
+		$sql = pl_build_sql('UPDATE', '`groups`:', $a);
 		$result = DB::query($sql);
 		return $result;
 	}

--- a/cms/app/lib/pikaAuthDb.php
+++ b/cms/app/lib/pikaAuthDb.php
@@ -73,9 +73,9 @@ class pikaAuthDb
 			$safe_identity = DB::escapeString($identity);
 			
 			$sql  = "SELECT user_id, username, enabled, password_expire, 
-					users.group_id AS group_name, groups.*, password
+					users.group_id AS group_name, `groups`.*, password
 					FROM {$this->table_name}
-					LEFT JOIN groups ON users.group_id=groups.group_id
+					LEFT JOIN `groups` ON users.group_id=groups.group_id
 					WHERE enabled = '1'
 					AND username='{$safe_identity}'
 					AND LENGTH(password) > 0";

--- a/cms/app/lib/pikaGroup.php
+++ b/cms/app/lib/pikaGroup.php
@@ -18,13 +18,13 @@ class pikaGroup extends plBase
 {
 	public function __construct($group_id = null)
 	{
-		$this->db_table = 'groups';
+		$this->db_table = '`groups`';
 		parent::__construct($group_id);
 		return true;
 	}
 	
 	public static function getGroupsDB() {
-		$sql = "SELECT * FROM groups WHERE 1";
+		$sql = "SELECT * FROM `groups` WHERE 1";
 		$result = DB::query($sql) or trigger_error("SQL: " . $sql . " Error: " . DB::error());
 		return $result;
 	}

--- a/cms/app/lib/pikaUserSession.php
+++ b/cms/app/lib/pikaUserSession.php
@@ -48,11 +48,11 @@ class pikaUserSession extends plBase
 			
 		}
 		// AMW - 2011-08-02 - Added users.password_expire.
-		$sql = "SELECT user_sessions.*, users.username, users.enabled, users.session_data, users.group_id AS group_name, groups.*, users.password_expire,
+		$sql = "SELECT user_sessions.*, users.username, users.enabled, users.session_data, users.group_id AS group_name, `groups`.*, users.password_expire,
 				(UNIX_TIMESTAMP() - last_updated) as seconds_elapsed
 				FROM user_sessions 
 				JOIN users ON user_sessions.user_id = users.user_id 
-				LEFT JOIN groups on groups.group_id = users.group_id 
+				LEFT JOIN `groups` on `groups`.group_id = users.group_id 
 				WHERE 1{$sql_filter}";
 
 		if($order != 'ASC') {$order = 'DESC'; }


### PR DESCRIPTION
GROUPS is a new reserved word in MySQL 8:
https://dev.mysql.com/doc/refman/8.0/en/keywords.html#keywords-new-in-current-series

This causes problems for OCM because OCM has a table called groups. Queries that reference this table therefore cause a syntax error if MySQL 8 is used in production. The issue can be resolved by wrapping the groups table name in backtics. 

Merry Christmas,

--AC