### PR TITLE
Remove notice about html tidy

### DIFF
--- a/cms/subtemplates/system-settings.html
+++ b/cms/subtemplates/system-settings.html
@@ -69,6 +69,5 @@
 		<input type="submit" name="gen" value="Save" class="save" tabindex="1" />
 		</form>
 		<br/><br/>
-		* - The HTML Tidy application from W3C.org should be installed if this option is enabled.
 	</div>
 </div>


### PR DESCRIPTION
Per the changelog for version 6 and various comments within the codebase, html tidy validation features were removed 2013-08-08. This notice on the system settings screen does not refer to anything functional any longer.