### PR TITLE
fix for when cms-custom/extensions/ does not exist

### DIFF
--- a/cms/system-extensions.php
+++ b/cms/system-extensions.php
@@ -14,7 +14,7 @@ function scan_extension_folder($subdir, $base_path)
 	$a = array();
 	$h = opendir($path);
 	
-	while (false !== ($entry = readdir($h))) 
+	while ($h != false && false !== ($entry = readdir($h))) 
 	{
 	    if ($entry != "." && $entry != ".." && is_dir($path . "/" . $entry))
 	    {


### PR DESCRIPTION
When the `extensions` folder does not exist within [cms-custom](url), (as is the case in the master repository), `cms/systems-extensions.php` will fail to load with a server error 503. I believe that what is happening is exactly what is described in this comment regarding this type of syntax creating an infinite loop if the filehandle is `false` (as will be the case when the directory cannot be opened) rather than of a filehandle type:

https://stackoverflow.com/questions/7630245/explaination-of-whilefalse-f-readdird/7630285#comment89057755_7630312

I believe what is happening is that the condition is checking whether `($entry = readdir($h))` resulted in an assignment, which is not adequate because even when the directory does not exist, an assignment will still occur because `readdir()` returns the boolean `false` on failure: https://www.geeksforgeeks.org/php-readdir-function/. `$entry` then is assigned the value `false`, and because an assignment occurred successfully, then the while loop is just evaluating the condition `while (false !== true)`

My suggestion to fix the issue so that this screen does not enter an infinite loop and throw server error 503 when `cms-custom/extensions/` does not exist is to simply check to make sure that `$h` itself is not `false` as an additional condition in the while loop.