### PR TITLE
ASC or DESC qualifiers for GROUP BY rewrite as ORDER BY

### DIFF
--- a/cms/reports/lsc_gap/report.php
+++ b/cms/reports/lsc_gap/report.php
@@ -113,7 +113,7 @@ if ($x != false) {
 	$sql .= " AND status IN $x";
 }
 
-$sql .= " GROUP BY category ASC WITH ROLLUP";
+$sql .= " GROUP BY category WITH ROLLUP ORDER BY category ASC";
 
 $t->set_title($report_title);
 $t->display_row_count(false);


### PR DESCRIPTION
ASC or DESC qualifiers for GROUP BY were removed from MySQL in version 8.0.13 in October 2018.  

From [https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-13.html](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-13.html):

> SQL Syntax Notes
> Incompatible Change: The deprecated ASC or DESC qualifiers for GROUP BY clauses have been removed. Queries that previously relied on GROUP BY sorting may produce results that differ from previous MySQL versions. To produce a given sort order, provide an ORDER BY clause.
> 
> Queries and stored program definitions from MySQL 8.0.12 or lower that use ASC or DESC qualifiers for GROUP BY clauses should be amended. Otherwise, upgrading to MySQL 8.0.13 or higher may fail, as may replicating to MySQL 8.0.13 or higher slave servers.

This patch follows Oracle's guidance by providing an ORDER BY clause instead in order to produce the desired sort order. 