### PR TITLE
missing assignment from POST vars to $show_sql

### DIFF
--- a/cms/reports/inactive_case/report.php
+++ b/cms/reports/inactive_case/report.php
@@ -33,6 +33,7 @@ $funding = pl_grab_post('funding');
 $office = pl_grab_post('office');
 $status = pl_grab_post('status');
 $limit = pl_grab_post('limit');
+$show_sql = pl_grab_post('show_sql');
 
 $menu_case_status = pl_menu_get('case_status');
 $menu_office = pl_menu_get('office');

--- a/cms/reports/inactive_user/report.php
+++ b/cms/reports/inactive_user/report.php
@@ -27,6 +27,7 @@ if(!pika_report_authorize($report_name)) {
 $report_format = pl_grab_post('report_format');
 $inactive_date_begin = pl_grab_post('inactive_date_begin');
 $limit = pl_grab_post('limit');
+$show_sql = pl_grab_post('show_sql');
 
 $menu_act_type = pl_menu_get('act_type');
 $staff_array = pikaUser::getUserArray();

--- a/cms/reports/lsc_ar/report.php
+++ b/cms/reports/lsc_ar/report.php
@@ -34,6 +34,7 @@ $status = pl_grab_post('status');
 $county = pl_grab_post('county');
 $gender = pl_grab_post('gender');
 $undup = pl_grab_post('undup');
+$show_sql = pl_grab_post('show_sql');
 
 $menu_undup = pl_menu_get('undup');
 

--- a/cms/reports/lsc_csr/report.php
+++ b/cms/reports/lsc_csr/report.php
@@ -31,6 +31,7 @@ $office = pl_grab_post('office');
 $status = pl_grab_post('status');
 $county = pl_grab_post('county');
 $undup = pl_grab_post('undup');
+$show_sql = pl_grab_post('show_sql');
 
 $menu_undup = pl_menu_get('undup');
 

--- a/cms/reports/lsc_gap/report.php
+++ b/cms/reports/lsc_gap/report.php
@@ -33,6 +33,7 @@ $funding = pl_grab_post('funding');
 $office = pl_grab_post('office');
 $status = pl_grab_post('status');
 $undup = pl_grab_post('undup');
+$show_sql = pl_grab_post('show_sql');
 
 $office_menu = pl_menu_get('office');
 $menu_undup = pl_menu_get('undup');

--- a/cms/reports/lsc_household/report.php
+++ b/cms/reports/lsc_household/report.php
@@ -34,6 +34,7 @@ $status = pl_grab_post('status');
 $county = pl_grab_post('county');
 $gender = pl_grab_post('gender');
 $undup = pl_grab_post('undup');
+$show_sql = pl_grab_post('show_sql');
 
 $menu_undup = pl_menu_get('undup');
 

--- a/cms/reports/lsc_services/report.php
+++ b/cms/reports/lsc_services/report.php
@@ -69,6 +69,7 @@ $funding = pl_grab_post('funding');
 $office = pl_grab_post('office');
 $status = pl_grab_post('status');
 $county = pl_grab_post('county');
+$show_sql = pl_grab_post('show_sql');
 
 pl_menu_get('lsc_other_services');
 pl_menu_get('problem_2007');

--- a/cms/reports/opposing/report.php
+++ b/cms/reports/opposing/report.php
@@ -37,6 +37,7 @@ $office = pl_grab_post('office');
 $problem = pl_grab_post('problem');
 $funding = pl_grab_post('funding');
 $user_id = pl_grab_post('user_id');
+$show_sql = pl_grab_post('show_sql');
 
 $opposing_name = pl_grab_post('opposing_name');
 

--- a/cms/reports/red_flag/report.php
+++ b/cms/reports/red_flag/report.php
@@ -34,6 +34,7 @@ $funding = pl_grab_post('funding');
 $office = pl_grab_post('office');
 $status = pl_grab_post('status');
 $limit = pl_grab_post('limit');
+$show_sql = pl_grab_post('show_sql');
 
 $menu_case_status = pl_menu_get('case_status');
 $menu_office = pl_menu_get('office');


### PR DESCRIPTION
In some of the canned reports included with Pika/OCM, clicking the "show sql" checkbox does not have any effect on the generated report because of a missing variable assignment in the report.php file for the report. This patch adds in these assignments.